### PR TITLE
Add support for all languages using `//` as a comment

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
   intellijPlatform {
     intellijIdeaCommunity(providers.gradleProperty("platformVersion").get())
     bundledPlugin("com.intellij.java")
+    bundledPlugin("org.intellij.groovy")
     testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Platform)
     zipSigner()
   }

--- a/src/main/kotlin/com/saket/commentcontinuation/StringScanLineCommentDetector.kt
+++ b/src/main/kotlin/com/saket/commentcontinuation/StringScanLineCommentDetector.kt
@@ -1,5 +1,6 @@
 package com.saket.commentcontinuation
 
+import com.intellij.lang.LanguageCommenters
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiDocumentManager
@@ -19,10 +20,13 @@ class StringScanLineCommentDetector : LineCommentDetector {
     psiDocumentManager.commitDocument(editor.document)
     val psiFile = psiDocumentManager.getPsiFile(editor.document) ?: return null
 
-    // The raw precheck keeps PSI off the hot path for normal Enter presses. Once we are here,
-    // use PSI only as a semantic confirmation that this is a supported Java/Kotlin line comment.
-    val fileExtension = psiFile.virtualFile?.extension ?: psiFile.fileType.defaultExtension
-    if (fileExtension !in supportedFileExtensions) return null
+    // Gate on the language's registered line-comment prefix rather than a hardcoded extension
+    // list. Any language plugin the host IDE has installed whose line comments are `//` is
+    // supported automatically (Java, Kotlin, JavaScript, TypeScript, Go, Rust, C/C++, Scala,
+    // Dart, etc.); languages with different prefixes are excluded (Python/Properties `#`,
+    // Lua `--`), as are files the IDE only recognizes as plain text.
+    val commenter = LanguageCommenters.INSTANCE.forLanguage(psiFile.language)
+    if (commenter?.lineCommentPrefix != "//") return null
 
     val element = psiFile.findElementAt(lineCommentMatch.start) ?: return null
     val comment = (element as? PsiComment)
@@ -73,6 +77,5 @@ class StringScanLineCommentDetector : LineCommentDetector {
   @Suppress("ConstPropertyName")
   private companion object {
     private const val MinimumCommentPrefixLength = 2
-    private val supportedFileExtensions = setOf("java", "kt")
   }
 }

--- a/src/main/kotlin/com/saket/commentcontinuation/StringScanLineCommentDetector.kt
+++ b/src/main/kotlin/com/saket/commentcontinuation/StringScanLineCommentDetector.kt
@@ -25,6 +25,11 @@ class StringScanLineCommentDetector : LineCommentDetector {
     // supported automatically (Java, Kotlin, JavaScript, TypeScript, Go, Rust, C/C++, Scala,
     // Dart, etc.); languages with different prefixes are excluded (Python/Properties `#`,
     // Lua `--`), as are files the IDE only recognizes as plain text.
+    //
+    // Steady-state cost is one UserData hash lookup per call — `forLanguage` memoizes the
+    // resolved Commenter on the Language instance, so this stays well behind the PSI element
+    // lookup it gates. See the implementation:
+    // https://github.com/JetBrains/intellij-community/blob/dd4894eafeec9cdf946cb167d97c5fe6b2cbb9a2/platform/core-api/src/com/intellij/lang/LanguageExtension.java#L98-L107
     val commenter = LanguageCommenters.INSTANCE.forLanguage(psiFile.language)
     if (commenter?.lineCommentPrefix != "//") return null
 

--- a/src/test/kotlin/com/saket/commentcontinuation/ContinueLineCommentHandlerTest.kt
+++ b/src/test/kotlin/com/saket/commentcontinuation/ContinueLineCommentHandlerTest.kt
@@ -177,9 +177,19 @@ class ContinueLineCommentHandlerTest : BasePlatformTestCase() {
     assertThat(lines.last().trimStart().startsWith("//")).isFalse()
   }
 
-  @Test fun `does not continue comments in unsupported file types`() {
+  @Test fun `does not continue in languages whose line comment prefix is not slash slash`() {
+    // Properties files use `#` for line comments, so even a literal `//` at the start of a line
+    // should not trigger continuation.
     installHandlers()
-    myFixture.configureByText("test.js", "// hello<caret>")
+    myFixture.configureByText("test.properties", "// hello<caret>")
+    myFixture.performEditorAction(IdeActions.ACTION_EDITOR_ENTER)
+    assertThat(myFixture.editor.document.text).doesNotContain("\n// ")
+  }
+
+  @Test fun `does not continue in plain text files`() {
+    // Plain text has no Commenter at all, so `//` is just text.
+    installHandlers()
+    myFixture.configureByText("test.txt", "// hello<caret>")
     myFixture.performEditorAction(IdeActions.ACTION_EDITOR_ENTER)
     assertThat(myFixture.editor.document.text).doesNotContain("\n// ")
   }

--- a/src/test/kotlin/com/saket/commentcontinuation/ContinueLineCommentHandlerTest.kt
+++ b/src/test/kotlin/com/saket/commentcontinuation/ContinueLineCommentHandlerTest.kt
@@ -44,6 +44,23 @@ class ContinueLineCommentHandlerTest : BasePlatformTestCase() {
     )
   }
 
+  @Test fun `continues a Groovy comment when pressing enter at the end`() {
+    // Groovy is not in the original {java, kt} allowlist, but its line comment prefix is `//`,
+    // so the Commenter-based gate should accept it.
+    testEnter(
+      fileName = "test.groovy",
+      before =
+        """
+        >// hello▮
+        """.trimMargin(">"),
+      after =
+        """
+        >// hello
+        >// ▮
+        """.trimMargin(">"),
+    )
+  }
+
   @Test fun `keeps leading spaces on the next line`() {
     testEnter(
       fileName = "test.java",


### PR DESCRIPTION
Closes #4. (Aware of the alternative approach in #5 — happy to defer to whichever direction you prefer.)

Replaces the hardcoded `{java, kt}` extension allowlist in `StringScanLineCommentDetector` with a check against the language's registered `Commenter` (`LanguageCommenters.INSTANCE.forLanguage(...)`). Any language whose `lineCommentPrefix` is `//` is now supported automatically — Java, Kotlin, TypeScript, etc. — without having to maintain an extension list. 

Languages with a different prefix (Python/Properties `#`, Lua `--`) and plain-text files are still excluded, which maybe means this is a less ideal fix than #5.

### Performance

The detector's layered fast-path is preserved: `LanguageCommenters.forLanguage(...)` is backed by per-`Language` `UserData` caching, so steady-state cost is one hash-map get plus a string compare — comparable to the old `Set<String>.contains` lookup.

### Tests

- **Positive coverage for a previously-unsupported language**: added a `.groovy` continuation test. Groovy is bundled with IDEA Community and isn't in the original `{java, kt}` allowlist, so it exercises the new gate end-to-end (string scan → Commenter check → PSI confirmation → continuation).
- **Negative coverage for the gate's reject paths**: replaced the `.js` "unsupported file types" case (which becomes a positive case in any IDE with the JS plugin) with two clearer negatives — `.properties` (Commenter exists, prefix is `#`) and `.txt` (no Commenter at all).
- I couldn't add a test for `.ts` etc: those parsers ship in Ultimate-tier plugins, and an attempt to swap the test platform to `intellijIdeaUltimate` failed for unrelated reasons (a Swagger plugin bundled in Ultimate references a test-only class that isn't on the runtime classpath, breaking the platform test fixture before any test body runs). The `Commenter`-based gate is correct by construction for those languages — each registers `lineCommentPrefix = "//"` — and the Groovy test confirms the gate works for any new `//` language without extension-allowlist changes.